### PR TITLE
Refactor to fully-class based and add exception handling

### DIFF
--- a/ssawg_trending_scraper.py
+++ b/ssawg_trending_scraper.py
@@ -17,6 +17,7 @@ import re
 import traceback
 from datetime import datetime
 from pathlib import Path
+import time
 
 import jinja2
 import requests
@@ -308,10 +309,6 @@ class PerigeePage(BasePage):
         return html_chunks
 
 
-# Get main program options before any other processing
-opt = get_opt()
-
-
 class KalmanWatch3Page(GenericPage):
     page = "kalman_watch3"
 
@@ -474,6 +471,9 @@ class FssCheck3Page(GenericPage):
 
 
 def main():
+    # Get main program options before any other processing
+    opt = get_opt()
+
     html_chunks = []
 
     for page_class in BasePage.page_classes:
@@ -498,7 +498,7 @@ def main():
     with open(data_dir / "ssawg_trending_template.html", "r") as fh:
         template_text = fh.read()
     template = jinja2.Template(template_text)
-    out_html = template.render(html_chunks=html_chunks)
+    out_html = template.render(html_chunks=html_chunks, update_time=time.ctime())
     with open(data_dir / "ssawg_trending.html", "w") as trending_file:
         trending_file.write(out_html)
 

--- a/ssawg_trending_scraper.py
+++ b/ssawg_trending_scraper.py
@@ -189,7 +189,8 @@ class ReportsPage(BasePage):
                 halfway = start_time.secs + ((stop_time.secs - start_time.secs) / 2)
                 # is now > 50% through quarter?
                 if DateTime().secs > halfway:
-                    return f"{URL_ASPECT}/{self.page}/{year}/Q{quarter}/", ""
+                    url = f"{URL_ASPECT}/{self.page}/{year}/Q{quarter}/"
+                    return url, url
                 # if not 50% through and it's the first quarter of the year
                 elif quarter == 1:
                     # switch to fourth quarter of previous year

--- a/ssawg_trending_scraper.py
+++ b/ssawg_trending_scraper.py
@@ -12,25 +12,26 @@ Usage::
     $ python ssawg_trending_scraper.py ...
 """
 import argparse
+import html
+import re
+import traceback
+from datetime import datetime
 from pathlib import Path
 
+import jinja2
 import requests
 import Ska.ftp
-from Chandra.Time import DateTime
 from astropy.table import Table
 from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
-import re
-import jinja2
-
+from Chandra.Time import DateTime
 
 # ------------------------------------
 # Setup for password-protected site(s)
 # ------------------------------------
 
 NETRC = Ska.ftp.parse_netrc()
-if 'periscope_drift_page' not in NETRC:
-    raise RuntimeError('must have periscope_drift_page authentication in ~/.netrc')
+if "periscope_drift_page" not in NETRC:
+    raise RuntimeError("must have periscope_drift_page authentication in ~/.netrc")
 
 # -----------------------------------
 # Establish base URL, trending pages,
@@ -41,11 +42,10 @@ URL_ASPECT = "https://cxc.cfa.harvard.edu/mta/ASPECT"
 
 
 def get_opt():
-    parser = argparse.ArgumentParser(description='Make SSAWG trending page')
-    parser.add_argument('--data-dir',
-                        type=str,
-                        default='.',
-                        help='Output data directory')
+    parser = argparse.ArgumentParser(description="Make SSAWG trending page")
+    parser.add_argument(
+        "--data-dir", type=str, default=".", help="Output data directory"
+    )
 
     args = parser.parse_args()
 
@@ -65,10 +65,10 @@ def get_images(soup, image, url):
     """
     images = {}
     for img in soup.find_all(image):
-        if img['src'].endswith('.png') or img['src'].endswith("gif"):
+        if img["src"].endswith(".png") or img["src"].endswith("gif"):
             # look for all pngs and gifs
             new_image_url = f'<img src = "{url}{img["src"]}" style="max-width:800px">'
-            images[img['src']] = new_image_url
+            images[img["src"]] = new_image_url
     return images
 
 
@@ -88,18 +88,26 @@ def get_tables(soup, tbl, url):
 # ---------------------------------
 # Establish HTML info for each page
 # ---------------------------------
-class BasePage():
+class BasePage:
     """
     Base class for establishing page, URL, and HTML information.
     """
-    auth = None
 
-    def __init__(self, page):
-        self.page = page
+    page = None
+    auth = None
+    page_classes = []
+
+    def __init_subclass__(cls, *args, **kwargs) -> None:
+        if cls.page is not None:
+            BasePage.page_classes.append(cls)
+            super().__init_subclass__(*args, **kwargs)
+
+    def parse_page(self):
         # self.current_url preserves ability to grab data from
         # current urls, versus conditional dates later
         # (e.g. acq stats report - acq ids image)
         self.url, self.current_url = self.get_url()
+        self.url_html = f"<a href = {str(self.url)}>{str(self.url)}</a><br>"
 
         # Generate the page requests and verify page is accessible
         self.page_request = self.get_page_request()
@@ -107,9 +115,9 @@ class BasePage():
         self.url_text = self.page_request.text
         self.soup = BeautifulSoup(self.url_text, "lxml")
         if self.page != "celmon":
-            for local_link in self.soup.find_all('a'):
-                temp = local_link['href']
-                local_link['href'] = self.url + temp
+            for local_link in self.soup.find_all("a"):
+                temp = local_link["href"]
+                local_link["href"] = self.url + temp
 
         # Get various element types
         self.titles = get_elements(self.soup, "title")
@@ -124,10 +132,11 @@ class BasePage():
         self.scripts = get_elements(self.soup, "script")
         self.images = get_images(self.soup, "img", self.url)
         if self.page == "acq_stat_reports":
-            self.current_quarter_acq_images = get_images(self.soup, "img", self.current_url)
+            self.current_quarter_acq_images = get_images(
+                self.soup, "img", self.current_url
+            )
 
         self.tables = get_tables(self.soup, "table", self.url)
-        self.url_html = f'<a href = {str(self.url)}>{str(self.url)}</a><br>'
 
     def get_page_request(self):
         if self.auth:
@@ -136,17 +145,20 @@ class BasePage():
             page_request = requests.get(self.url)
 
         if page_request.status_code != 200:
-            raise RuntimeError(f'Investigate issues with {self.url}')
+            raise RuntimeError(f"Investigate issues with {self.url}")
 
         return page_request
 
     def get_url(self):
         raise NotImplementedError
 
+    def make_html(self):
+        raise NotImplementedError
+
 
 class GenericPage(BasePage):
     def get_url(self):
-        return f'{URL_ASPECT}/{self.page}/', ''
+        return f"{URL_ASPECT}/{self.page}/", ""
 
 
 class ReportsPage(BasePage):
@@ -157,7 +169,7 @@ class ReportsPage(BasePage):
         for quarter in range(4, 0, -1):
             year = datetime.now().year
             # creates the temporary url; starts at Quarter 4 and works backwards
-            url = f'{URL_ASPECT}/{self.page}/{year}/Q{quarter}/'
+            url = f"{URL_ASPECT}/{self.page}/{year}/Q{quarter}/"
             # this page requires a username/password
             if self.auth:
                 page_request = requests.get(url, auth=self.auth)
@@ -166,37 +178,106 @@ class ReportsPage(BasePage):
 
             if page_request.status_code == 200:
                 # use astropy Table
-                table_page = (Table.read(page_request.text, format='ascii.html',
-                                         htmldict={'table_id': 2}))
+                table_page = Table.read(
+                    page_request.text, format="ascii.html", htmldict={"table_id": 2}
+                )
                 # pull quarterly start and stop dates from page
-                start_time = DateTime(table_page['TSTART'][0])
-                stop_time = DateTime(table_page['TSTOP'][0])
+                start_time = DateTime(table_page["TSTART"][0])
+                stop_time = DateTime(table_page["TSTOP"][0])
                 # define halfway through the quarter
                 halfway = start_time.secs + ((stop_time.secs - start_time.secs) / 2)
                 # is now > 50% through quarter?
                 if DateTime().secs > halfway:
-                    return f'{URL_ASPECT}/{self.page}/{year}/Q{quarter}/', ''
+                    return f"{URL_ASPECT}/{self.page}/{year}/Q{quarter}/", ""
                 # if not 50% through and it's the first quarter of the year
                 elif quarter == 1:
                     # switch to fourth quarter of previous year
-                    return (f'{URL_ASPECT}/{self.page}/{year-1}/Q4/',
-                            f'{URL_ASPECT}/{self.page}/{year}/Q{quarter}/')
+                    return (
+                        f"{URL_ASPECT}/{self.page}/{year-1}/Q4/",
+                        f"{URL_ASPECT}/{self.page}/{year}/Q{quarter}/",
+                    )
                 else:
                     # try previous quarter
-                    return (f'{URL_ASPECT}/{self.page}/{year}/Q{quarter-1}/',
-                            f'{URL_ASPECT}/{self.page}/{year}/Q{quarter}/')
+                    return (
+                        f"{URL_ASPECT}/{self.page}/{year}/Q{quarter-1}/",
+                        f"{URL_ASPECT}/{self.page}/{year}/Q{quarter}/",
+                    )
             else:
                 continue
 
-        raise RuntimeError(f'failed to find URL for {self.page}')
+        raise RuntimeError(f"failed to find URL for {self.page}")
+
+
+class AcqStatReportsPage(ReportsPage):
+    page = "acq_stat_reports"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers3[0],
+            self.tables[1],
+            self.current_quarter_acq_images["id_acq_stars.png"],
+            self.images["delta_mag_scatter.png"],
+            self.tables[4],
+            "<hr>",
+        ]
+        return html_chunks
+
+
+class GuiStatReportsPage(ReportsPage):
+    page = "gui_stat_reports"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers3[0],
+            self.tables[1],
+            "<table><tbody><tr><td>",
+            self.images["delta_mag_vs_mag.png"],
+            "</td><td>",
+            self.images["delta_mag_vs_color.png"],
+            "</td></tr><tr><td>",
+            self.images["frac_not_track_vs_mag.png"],
+            "</td><td>",
+            self.images["frac_bad_obc_status.png"],
+            "</td></tr></tbody></table>",
+            self.tables[4],
+            "<hr>",
+        ]
+        return html_chunks
 
 
 class PeriscopePage(ReportsPage):
-    auth = (NETRC['periscope_drift_page']['login'],
-            NETRC['periscope_drift_page']['password'])
+    page = "periscope_drift_reports"
+    auth = (
+        NETRC["periscope_drift_page"]["login"],
+        NETRC["periscope_drift_page"]["password"],
+    )
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers3[0],
+            self.tables[1],
+            self.headers3[1],
+            self.images["drift_histogram.png"],
+            self.headers3[2],
+            "<table><tbody><tr><td>",
+            self.images["large_drift_ang_y_corr.png"],
+            "</td><td>",
+            self.images["large_drift_ang_z_corr.png"],
+            "</td></tr></tbody></table>",
+            "<hr>",
+        ]
+        return html_chunks
 
 
 class PerigeePage(BasePage):
+    page = "perigee_health_plots"
+
     def get_url(self):
         """
         Get the correct URL for the monthly perigee page; 50% through month.
@@ -204,238 +285,223 @@ class PerigeePage(BasePage):
         now = datetime.now()
         # if ~halfway through the month
         if DateTime().day > 15:
-            return f'{URL_ASPECT}/{self.page}/SUMMARY_DATA/{now.year}-M{now.month:02}/', ''
+            return (
+                f"{URL_ASPECT}/{self.page}/SUMMARY_DATA/{now.year}-M{now.month:02}/",
+                "",
+            )
         else:
             last_month = DateTime() - 27
-            return (f'{URL_ASPECT}/{self.page}/SUMMARY_DATA/{last_month.year}'
-                    f'-M{last_month.mon:02}/', '')
+            return (
+                f"{URL_ASPECT}/{self.page}/SUMMARY_DATA/{last_month.year}"
+                f"-M{last_month.mon:02}/",
+                "",
+            )
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers3[0],
+            self.url_html,
+            self.paragraphs[0],
+            self.tables[1],
+            "<hr>",
+        ]
+        return html_chunks
 
 
 # Get main program options before any other processing
 opt = get_opt()
 
-trending_pages = {
-    ReportsPage: [
-        "acq_stat_reports",
-        "gui_stat_reports"],
-    PeriscopePage: [
-        "periscope_drift_reports"],
-    PerigeePage: [
-        "perigee_health_plots"],
-    GenericPage: [
-        "kalman_watch3",
-        "obc_rate_noise/trending",
-        "fid_drift",
-        "aimpoint_mon",
-        "celmon",
-        "vv_rms",
-        "attitude_error_mon",
-        "fss_check3",
-    ]
-}
 
-trending_blocks = {}
-for page_class in trending_pages:
-    for page in trending_pages[page_class]:
-        trending_blocks[page] = page_class(page)
+class KalmanWatch3Page(GenericPage):
+    page = "kalman_watch3"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers3[0],
+            self.paragraphs[1],
+            self.divs[0],
+            self.tables[1],
+            "<hr>",
+        ]
+        return html_chunks
 
 
-# --------------------------------------------
-# Create consolidated block of necessary web
-# information in the order requested.
-# --------------------------------------------
+class ObcRateNoisePage(GenericPage):
+    page = "obc_rate_noise/trending"
 
-html_chunks = []
-
-tb = trending_blocks['kalman_watch3']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    tb.headers3[0],
-    tb.paragraphs[1],
-    tb.divs[0],
-    tb.tables[1],
-    "<hr>",
-])
-
-tb = trending_blocks['acq_stat_reports']
-html_chunks.extend([
-    trending_blocks["acq_stat_reports"].headers2[0],
-    tb.url_html,
-    tb.headers3[0],
-    tb.tables[1],
-    tb.current_quarter_acq_images["id_acq_stars.png"],
-    tb.images["delta_mag_scatter.png"],
-    tb.tables[4],
-    "<hr>",
-])
-
-tb = trending_blocks['gui_stat_reports']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    tb.headers3[0],
-    tb.tables[1],
-    "<table><tbody><tr><td>",
-    tb.images["delta_mag_vs_mag.png"],
-    "</td><td>",
-    tb.images["delta_mag_vs_color.png"],
-    "</td></tr><tr><td>",
-    tb.images["frac_not_track_vs_mag.png"],
-    "</td><td>",
-    tb.images["frac_bad_obc_status.png"],
-    "</td></tr></tbody></table>",
-    tb.tables[4],
-    "<hr>",
-])
-
-tb = trending_blocks['perigee_health_plots']
-html_chunks.extend([
-    tb.headers3[0],
-    tb.url_html,
-    tb.paragraphs[0],
-    tb.tables[1],
-    "<hr>",
-])
-
-tb = trending_blocks['periscope_drift_reports']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    tb.headers3[0],
-    tb.tables[1],
-    tb.headers3[1],
-    tb.images['drift_histogram.png'],
-    tb.headers3[2],
-    "<table><tbody><tr><td>",
-    tb.images['large_drift_ang_y_corr.png'],
-    "</td><td>",
-    tb.images['large_drift_ang_z_corr.png'],
-    "</td></tr></tbody></table>",
-    "<hr>",
-])
-
-tb = trending_blocks['obc_rate_noise/trending']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    '<br>',
-    tb.headers2[0].next_sibling,
-    '<br><br>',
-    tb.images["pitch_time_recent.png"],
-    tb.images["yaw_time_recent.png"],
-    tb.images["roll_time_recent.png"],
-    tb.images["pitch_time_longterm.png"],
-    tb.images["yaw_time_longterm.png"],
-    tb.images["roll_time_longterm.png"],
-    "<hr>",
-])
-
-tb = trending_blocks['fid_drift']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    tb.headers4[0],
-    tb.headers4[0].next_sibling,
-    "<br>",
-    tb.images["starcheck_telem.png"],
-    tb.images["drift_acis_s.png"],
-    "<hr>",
-])
-
-tb = trending_blocks['aimpoint_mon']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    tb.headers3[1],
-    tb.headers3[1].next_sibling,
-    tb.tts[0],
-    tb.tts[0].next_sibling,
-    tb.divs[0],
-    tb.scripts[0],
-    tb.divs[1],
-    tb.scripts[1],
-    tb.headers3[2],
-    tb.headers3[2].next_sibling,
-    tb.ems[2],
-    tb.ems[2].next_sibling,
-    tb.anchors[9],
-    tb.anchors[9].next_sibling,
-    tb.divs[2],
-    tb.scripts[2],
-    "<hr>",
-])
-
-tb = trending_blocks['celmon']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    tb.headers4[1],
-    tb.paragraphs[1],
-    tb.paragraphs[5],
-    tb.images["offsets-ACIS-S-history.png"],
-    tb.images["offsets-ACIS-I-history.png"],
-    tb.images["offsets-HRC-S-history.png"],
-    tb.images["offsets-HRC-I-history.png"],
-    "<hr>",
-])
-
-tb = trending_blocks['vv_rms']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.headers3[0],
-    tb.url_html,
-    "<br><br><table><tbody><tr><td>",
-    tb.images["hist2d_fig.png"],
-    "</td><td>",
-    tb.images["hist2d_fig_n100.png"],
-    "</td></tr></tbody></table>",
-    "<hr>",
-])
-
-tb = trending_blocks['attitude_error_mon']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.headers2[0].next_sibling,
-    "<br><br>",
-    tb.url_html,
-    tb.headers3[0],
-    tb.images["one_shot_vs_angle.png"],
-    tb.headers3[1],
-    tb.paragraphs[1],
-    "<br><br><table><tbody><tr><td>",
-    tb.images["roll_err_vs_time.png"],
-    "</td><td>",
-    tb.images["roll_err_hist.png"],
-    "</td></tr><tr><td>",
-    tb.images["point_err_vs_time.png"],
-    "</td><td>",
-    tb.images["point_err_hist.png"],
-    "</td></tr></tbody></table>",
-    "<hr>",
-])
-
-tb = trending_blocks['fss_check3']
-html_chunks.extend([
-    tb.headers2[0],
-    tb.url_html,
-    "<br>",
-    tb.anchors[1],
-    tb.tables[2],
-    "<hr>",
-])
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            "<br>",
+            self.headers2[0].next_sibling,
+            "<br><br>",
+            self.images["pitch_time_recent.png"],
+            self.images["yaw_time_recent.png"],
+            self.images["roll_time_recent.png"],
+            self.images["pitch_time_longterm.png"],
+            self.images["yaw_time_longterm.png"],
+            self.images["roll_time_longterm.png"],
+            "<hr>",
+        ]
+        return html_chunks
 
 
-# --------------------------------------
-# Export through Jinja trending template
-# file: trending_template.html
-# --------------------------------------
+class FidDriftPage(GenericPage):
+    page = "fid_drift"
 
-data_dir = Path(opt.data_dir)
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers4[0],
+            self.headers4[0].next_sibling,
+            "<br>",
+            self.images["starcheck_telem.png"],
+            self.images["drift_acis_s.png"],
+            "<hr>",
+        ]
+        return html_chunks
 
-with open(data_dir / 'ssawg_trending_template.html', 'r') as fh:
-    template_text = fh.read()
-template = jinja2.Template(template_text)
-out_html = template.render(html_chunks=html_chunks)
-with open(data_dir / 'ssawg_trending.html', 'w') as trending_file:
-    trending_file.write(out_html)
+
+class AimpointMonPage(GenericPage):
+    page = "aimpoint_mon"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers3[1],
+            self.headers3[1].next_sibling,
+            self.tts[0],
+            self.tts[0].next_sibling,
+            self.divs[0],
+            self.scripts[0],
+            self.divs[1],
+            self.scripts[1],
+            self.headers3[2],
+            self.headers3[2].next_sibling,
+            self.ems[2],
+            self.ems[2].next_sibling,
+            self.anchors[9],
+            self.anchors[9].next_sibling,
+            self.divs[2],
+            self.scripts[2],
+            "<hr>",
+        ]
+        return html_chunks
+
+
+class CelmonPage(GenericPage):
+    page = "celmon"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            self.headers4[1],
+            self.paragraphs[1],
+            self.paragraphs[5],
+            self.images["offsets-ACIS-S-history.png"],
+            self.images["offsets-ACIS-I-history.png"],
+            self.images["offsets-HRC-S-history.png"],
+            self.images["offsets-HRC-I-history.png"],
+            "<hr>",
+        ]
+        return html_chunks
+
+
+class VvRmsPage(GenericPage):
+    page = "vv_rms"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.headers3[0],
+            self.url_html,
+            "<br><br><table><tbody><tr><td>",
+            self.images["hist2d_fig.png"],
+            "</td><td>",
+            self.images["hist2d_fig_n100.png"],
+            "</td></tr></tbody></table>",
+            "<hr>",
+        ]
+        return html_chunks
+
+
+class AttitudeErrorMonPage(GenericPage):
+    page = "attitude_error_mon"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.headers2[0].next_sibling,
+            "<br><br>",
+            self.url_html,
+            self.headers3[0],
+            self.images["one_shot_vs_angle.png"],
+            self.headers3[1],
+            self.paragraphs[1],
+            "<br><br><table><tbody><tr><td>",
+            self.images["roll_err_vs_time.png"],
+            "</td><td>",
+            self.images["roll_err_hist.png"],
+            "</td></tr><tr><td>",
+            self.images["point_err_vs_time.png"],
+            "</td><td>",
+            self.images["point_err_hist.png"],
+            "</td></tr></tbody></table>",
+            "<hr>",
+        ]
+        return html_chunks
+
+
+class FssCheck3Page(GenericPage):
+    page = "fss_check3"
+
+    def get_html_chunks(self):
+        html_chunks = [
+            self.headers2[0],
+            self.url_html,
+            "<br>",
+            self.anchors[1],
+            self.tables[2],
+            "<hr>",
+        ]
+        return html_chunks
+
+
+def main():
+    html_chunks = []
+
+    for page_class in BasePage.page_classes:
+        trend_page = page_class()
+        try:
+            trend_page.parse_page()
+            html_chunks.extend(trend_page.get_html_chunks())
+        except Exception:
+            html_traceback = html.escape(traceback.format_exc())
+            html_chunks.append(
+                f"<h2>{trend_page.page}: FAILED PROCESSING</h2>\n"
+                f"<pre>\n{html_traceback}\n</pre>\n"
+            )
+
+    # --------------------------------------
+    # Export through Jinja trending template
+    # file: trending_template.html
+    # --------------------------------------
+
+    data_dir = Path(opt.data_dir)
+
+    with open(data_dir / "ssawg_trending_template.html", "r") as fh:
+        template_text = fh.read()
+    template = jinja2.Template(template_text)
+    out_html = template.render(html_chunks=html_chunks)
+    with open(data_dir / "ssawg_trending.html", "w") as trending_file:
+        trending_file.write(out_html)
+
+
+if __name__ == "__main__":
+    main()

--- a/ssawg_trending_template.html
+++ b/ssawg_trending_template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
   <head>
-    <title>Trending Template</title>
+    <title>Aspect Trending</title>
     <link href="https://cxc.harvard.edu/mta/ASPECT/aspect.css" rel="stylesheet"
     type="text/css" media="all" />
     <style type="text/css">
@@ -30,6 +30,8 @@
  </tr>
 </table>
 <body>
+
+<h1> Aspect Trending (updated {{ update_time }})</h1>
   {% for html_chunk in html_chunks %}
   {{ html_chunk }}
   {% endfor %}
@@ -42,13 +44,13 @@
       <a href="/index.html">Chandra Science</a>&nbsp;|&nbsp;
       <a href="http://chandra.harvard.edu/">Chandra Home</a>&nbsp;|&nbsp;
       <a href="https://icxc.harvard.edu/">iCXC (CXC only)</a>&nbsp;|&nbsp;
-      
+
       </font></div>
       <font face="Arial,Helvetica,sans-serif">
 
          <br clear="all"><br>
          <table class="cxcfooter" align="left" cellpadding="3" cellspacing="3">
-         
+
          <tbody><tr>
          <td class="cxclogo" align="left" valign="middle"><img src="https://cxc.harvard.edu/incl/cxc-logo_sm45.jpg" border="0" alt="CXC Logo"></td>
          <td class="cxccolophon" align="left" valign="top">
@@ -56,17 +58,17 @@
          Center (CXC) is operated for NASA by the Smithsonian Astrophysical Observatory.</i><br>
          60 Garden Street, Cambridge, MA 02138 USA.&nbsp;&nbsp;&nbsp; Email: <a href="mailto:aspect_help@head.cfa.harvard.edu">aspect_help@head.cfa.harvard.edu</a><br>
          Smithsonian Institution, Copyright © 1998-2004. All rights reserved.
-         
+
          </font>
          </td>
          </tr>
          </tbody></table>
-          
+
          <!--footer end-->
-         
-           
-         
-         
+
+
+
+
          </font>
  </body>
 </html>


### PR DESCRIPTION
## Description

The existing aspect trending scraping code was failing due to bad upstream data and no output was being generated since the code halted. This PR addresses that by allowing any one trending page to fail without impacting the others.

Accomplishing that required a somewhat substantial refactoring to put everything related to one trending page into a corresponding class, so one class per page. However, the diffs are a lot more than the actual changes since it was mostly just moving stuff around.

In addition this PR adds a date stamp to the HTML output.

I also applied black and isort formatting, largely because doing the refactoring was much easier with the help of black to reformat/re-indent code.

### Testing

Ran this locally on my Mac and got the following:
https://cxc.harvard.edu/mta/ASPECT/tests/ssawg_trending_scraper/ssawg_trending.html