### PR TITLE
show latest kalman_watch plotly plot with STK radiation model

### DIFF
--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -333,10 +333,10 @@ class KalmanWatch3Page(GenericPage):
         html_chunks = [
             self.headers2[0],
             self.url_html,
-            self.images["mon_win_kalman_drops_-45d_-1d.png"],
+            self.divs[0],
             self.headers3[0],
             self.paragraphs[1],
-            self.divs[0],
+            self.divs[2],
             self.tables[1],
             "<hr>",
         ]


### PR DESCRIPTION
## Description

After kalman_watch 0.6.0 (after sot/kalman_watch/pull/16), the IR flag fraction plot will be a plotly plot, and not PNG. This PR changes the web scraper to show the new plot.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests

Not clear what is the best way to test, because everything is hardwired to the flight values.

I did the following:
```
from twiki_wg import ssawg_trending_scraper
class KalmanWatch3Page(ssawg_trending_scraper.KalmanWatch3Page):
    def get_url(self):
        return f"https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kalman_watch/pr-16/yearly/", ""
page = KalmanWatch3Page()
page.parse_page()
chunks = page.get_html_chunks()
```
and checked that each of the chunks corresponds to the right element on the page.
