### PR TITLE
Update AcqStatReportsPage

### DIFF
--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -213,8 +213,8 @@ class AcqStatReportsPage(GenericPage):
             self.headers3[1],
             self.images["quarter/id_acq_stars.png"],
             self.images["quarter/fail_rate_plot.png"],
+            self.images["quarter/fail_rate_plot_borderline.png"],
             self.images["quarter/mag_pointhist.png"],
-            self.images["quarter/delta_mag_scatter.png"],
             "<hr>",
         ]
         return html_chunks

--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -129,11 +129,6 @@ class BasePage:
         self.ems = get_elements(self.soup, "em")
         self.scripts = get_elements(self.soup, "script")
         self.images = get_images(self.soup, "img", self.url)
-        if self.page == "acq_stat_reports":
-            self.current_quarter_acq_images = get_images(
-                self.soup, "img", self.current_url
-            )
-
         self.tables = get_tables(self.soup, "table", self.url)
 
     def get_page_request(self):
@@ -208,18 +203,18 @@ class ReportsPage(BasePage):
         raise RuntimeError(f"failed to find URL for {self.page}")
 
 
-class AcqStatReportsPage(ReportsPage):
+class AcqStatReportsPage(GenericPage):
     page = "acq_stat_reports"
 
     def get_html_chunks(self):
         html_chunks = [
             self.headers2[0],
             self.url_html,
-            self.headers3[0],
-            self.tables[1],
-            self.current_quarter_acq_images["id_acq_stars.png"],
-            self.images["delta_mag_scatter.png"],
-            self.tables[4],
+            self.headers3[1],
+            self.images["quarter/id_acq_stars.png"],
+            self.images["quarter/fail_rate_plot.png"],
+            self.images["quarter/mag_pointhist.png"],
+            self.images["quarter/delta_mag_scatter.png"],
             "<hr>",
         ]
         return html_chunks


### PR DESCRIPTION
## Description

This PR updates the acq stat reports section of the SSAWG summary trending page.

These are the current changes:
- remove special handling for quarterly plots
- make AcqStatReportsPage inherit from GenericPage instead of ReportsPage (after removing the use of ska_report_ranges)
- add the plot of failed acquisition rate Vs time
- add the acquisition success Vs magnitude plot
- removed table at the bottom (as I figured the information is now in the acquisition success Vs magnitude plot)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Requires at least acq_stats_reports from https://github.com/sot/acq_stat_reports/pull/9.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
I rebase this branch on top of the branch from #35, and generated a test page doing:

```
twiki_test acq_stat_reports --url https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/acq_stat_reports
```

[output](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/twiki-wg/twiki-wg-pr36/)