### PR TITLE
Periscope drift

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     uses: sot/skare3/.github/workflows/package_build.yml@master
     with:
-      noarch: true
+      noarch: false
     secrets:
       CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
       CHANDRA_XRAY_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     uses: sot/skare3/.github/workflows/package_build.yml@master
     with:
-      noarch: true
+      noarch: false
     secrets:
       CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
       CHANDRA_XRAY_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}

--- a/twiki_wg/data/ssawg_trending_template.html
+++ b/twiki_wg/data/ssawg_trending_template.html
@@ -4,7 +4,17 @@
     <title>Aspect Trending</title>
     <link href="https://cxc.harvard.edu/mta/ASPECT/aspect.css" rel="stylesheet"
     type="text/css" media="all" />
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+          crossorigin="anonymous">
+
     <style type="text/css">
+      body {
+        /* max-width is set to 800px in aspect.css */
+        max-width: unset;
+      }
       tr.pink-bkg {
         background-color:#f88
       }
@@ -70,5 +80,12 @@
 
 
          </font>
+
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+    crossorigin="anonymous">
+  </script>
+
  </body>
 </html>

--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -83,6 +83,13 @@ def get_tables(soup, tbl, url):
     return new_tables
 
 
+def get_plotly_figures(soup):
+    plotly_figures = [
+        div for div in soup.find_all("div", attrs={"class": ["plotly-graph-div"]})
+    ]
+    return {p.attrs["id"]: p.fetchParents()[0] for p in plotly_figures}
+
+
 # ---------------------------------
 # Establish HTML info for each page
 # ---------------------------------
@@ -130,6 +137,7 @@ class BasePage:
         self.scripts = get_elements(self.soup, "script")
         self.images = get_images(self.soup, "img", self.url)
         self.tables = get_tables(self.soup, "table", self.url)
+        self.plotly_figures = get_plotly_figures(self.soup)
 
     def get_page_request(self):
         if self.auth:
@@ -244,8 +252,8 @@ class GuiStatReportsPage(ReportsPage):
         return html_chunks
 
 
-class PeriscopePage(ReportsPage):
-    page = "periscope_drift_reports"
+class PeriscopePage(GenericPage):
+    page = "periscope_drift"
     auth = (
         NETRC["periscope_drift_page"]["login"],
         NETRC["periscope_drift_page"]["password"],
@@ -255,17 +263,8 @@ class PeriscopePage(ReportsPage):
         html_chunks = [
             self.headers2[0],
             self.url_html,
-            self.headers3[0],
-            self.tables[1],
-            self.headers3[1],
-            self.images["drift_histogram.png"],
-            self.headers3[2],
-            "<table><tbody><tr><td>",
-            self.images["large_drift_ang_y_corr.png"],
-            "</td><td>",
-            self.images["large_drift_ang_z_corr.png"],
-            "</td></tr></tbody></table>",
-            "<hr>",
+            self.plotly_figures["drift_history_4"].fetchParents()[0],
+            self.plotly_figures["drift_figure_4"].fetchParents()[0],
         ]
         return html_chunks
 

--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -264,7 +264,7 @@ class PeriscopePage(GenericPage):
             self.headers2[0],
             self.url_html,
             self.plotly_figures["drift_history_4"].fetchParents()[0],
-            self.plotly_figures["drift_figure_4"].fetchParents()[0],
+            # self.plotly_figures["drift_figure_4"].fetchParents()[0],
         ]
         return html_chunks
 

--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -65,7 +65,7 @@ def get_images(soup, image, url):
     for img in soup.find_all(image):
         if img["src"].endswith(".png") or img["src"].endswith("gif"):
             # look for all pngs and gifs
-            new_image_url = f'<img src = "{url}{img["src"]}" style="max-width:800px">'
+            new_image_url = f'<img src = "{url}/{img["src"]}" style="max-width:800px">'
             images[img["src"]] = new_image_url
     return images
 
@@ -112,6 +112,9 @@ class BasePage:
         # current urls, versus conditional dates later
         # (e.g. acq stats report - acq ids image)
         self.url, self.current_url = self.get_url()
+        # this removes a trailing slash and index.html
+        # because a common pattern in what follows is {self.url}/{path}
+        url_root = re.sub("/$", "", re.sub("index.html$", "", self.url))
         self.url_html = f"<a href = {str(self.url)}>{str(self.url)}</a><br>"
 
         # Generate the page requests and verify page is accessible
@@ -122,7 +125,7 @@ class BasePage:
         if self.page != "celmon":
             for local_link in self.soup.find_all("a"):
                 temp = local_link["href"]
-                local_link["href"] = self.url + temp
+                local_link["href"] = f"{url_root}/{temp}"
 
         # Get various element types
         self.titles = get_elements(self.soup, "title")
@@ -135,8 +138,8 @@ class BasePage:
         self.divs = get_elements(self.soup, "div")
         self.ems = get_elements(self.soup, "em")
         self.scripts = get_elements(self.soup, "script")
-        self.images = get_images(self.soup, "img", self.url)
-        self.tables = get_tables(self.soup, "table", self.url)
+        self.images = get_images(self.soup, "img", url_root)
+        self.tables = get_tables(self.soup, "table", url_root)
         self.plotly_figures = get_plotly_figures(self.soup)
 
     def get_page_request(self):

--- a/twiki_wg/ssawg_trending_scraper.py
+++ b/twiki_wg/ssawg_trending_scraper.py
@@ -268,6 +268,7 @@ class PeriscopePage(GenericPage):
             self.url_html,
             self.plotly_figures["drift_history_4"].fetchParents()[0],
             # self.plotly_figures["drift_figure_4"].fetchParents()[0],
+            "<hr>",
         ]
         return html_chunks
 


### PR DESCRIPTION
## Description

This PR changes the scraper to fetch the latest version periscope drift trending.

I also changed the way the URL is cleaned-up. Originally, the script would remove trailing slashes so it can be used to construct derived paths. The problem is that sometimes one needs the trailing slash (e.g.: when using authentication, it fails if it is missing). After this PR, the URL is left unchanged so it can be requested without failure. Instead, I created a new variable `url_root` that holds the cleaned-up URL to be used for other paths.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests

Output of `twiki_wg.ssawg_trending_scraper` in this branch [HERE](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/twiki-wg/pr-38/)
